### PR TITLE
struct で定義されてる構造体のフィールド名と init で定義されてるフィールド名の修正

### DIFF
--- a/backend/Docker/mysql/init/1-rooms.sql
+++ b/backend/Docker/mysql/init/1-rooms.sql
@@ -14,7 +14,7 @@ CREATE TABLE data_sets.rooms(
 ) ENGINE = InnoDB;
 
 /* INSERT QUERY */
--- INSERT INTO
---     data_sets.rooms(id, room_name, member_amount, summary, is_open, last_update, room_parent, room_maker)
--- VALUES
---     (2, "test", 10, "3000円以内がいい", true, "2022-01-03", 1, "田中");
+INSERT INTO
+    data_sets.rooms(id, room_name, member_amount, summary, is_open, last_update, room_parent, room_maker)
+VALUES
+    (2, "test", 10, "3000円以内がいい", true, "2022-01-03", 1, "田中");

--- a/backend/go/cmd/main.go
+++ b/backend/go/cmd/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	// "github.com/SystemEngineeringTeam/Hack-U_2022/backend/go/router"
+	"fmt"
+
 	"github.com/SystemEngineeringTeam/Hack-U_2022/backend/go/lib"
 	"gorm.io/gorm"
 
@@ -9,17 +11,24 @@ import (
 )
 
 func main() {
+	//本番はrouter.Init()のみでいい
 	// router.Init()
+
+	// データベース接続確認 
+	//db connected!!　とコンソールに表示されたら接続成功
 	db := lib.SqlConnect()
-	print(db)
+
+	// データベースの値をとれているか確認
+	// &{2 test 10 3000円以内がいい true 2022-01-03 1 田中 []} と表示されれば成功
+	// 一番最後のから配列は member テーブルの情報が入るようにしたい
+	// struct.go に for文をまわして格納する用の関数を作るのが良さそう
+	res := GetRooms(db)
+	fmt.Println(res[0])
 }
 
-
-func GetBuildingName(building_name string, db *gorm.DB) []*models.Room {
+// テスト用の関数
+func GetRooms(db *gorm.DB) []*models.Room {
 	room := []*models.Room{}
-	// building_nameが空文字だった時
-
-	db.Where("room_name LIKE ?", "%"+"test"+"%").Find(&room)
-
+	db.Find(&room)
 	return room
 }

--- a/backend/go/models/structs.go
+++ b/backend/go/models/structs.go
@@ -3,21 +3,20 @@ package models
 type Room struct {
 	ID           int      `json:"roomId"`
 	RoomName     string   `json:"roomName"`
-	RoomMaker    string   `json:"roomMaker"`
-	LastUpdated  string   `json:"lastUpdated"`
 	MemberAmount int      `json:"memberAmount"`
 	Summary      string   `json:"summary"`
-	RoomChildren []string `json:"roomChildren"`
-	RoomParent   string   `json:"roomParent"`
-	Members      []Member `gorm:"foreignKey:RoomId"`
 	IsOpen       bool     `json:"isOpen"`
+	LastUpdate  string   `json:"lastUpdated"`
+	RoomParent   int      `json:"roomParent"`
+	RoomMaker    string   `json:"roomMaker"`
+	Members      []Member `gorm:"foreignKey:RoomId"`
 }
 
 type Member struct {
-	ID              int    `json:"memberId"`
-	RoomId          int    `json:"roomId"`
-	UserId          int    `gorm:"primaryKey"`
-	Name            string `json:"name"`
-	ResistationDate string `json:"resistationDate"`
-	Comment         string `json:"comment"`
+	ID               int    `json:"memberId"`
+	RoomId           int    `json:"roomId"`
+	UserId           int    `gorm:"primaryKey"`
+	UserName         string `json:"name"`
+	RegistrationDate string `json:"registrationDate"`
+	Comment          string `json:"comment"`
 }


### PR DESCRIPTION
## やったこと
- struct で定義されてる構造体のフィールド名と init で定義されてるフィールド名の修正

## やらないこと
- テーブル同士の結合

## できるようになること（ユーザ目線）
- 特になし

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
### コンテナ内で main.go を実行
```
/go/src/app/cmd # go run main.go 
db connected!!
&{2 test 10 3000円以内がいい true 2022-01-03 1 田中 []}
```
以上がコンソールに表示され、データベースと接続できていること、roomsテーブルから値が取れていることが確認できた

### 使用したデモデータ
```sql
INSERT INTO
    data_sets.rooms(id, room_name, member_amount, summary, is_open, last_update, room_parent, room_maker)
VALUES
    (2, "test", 10, "3000円以内がいい", true, "2022-01-03", 1, "田中");
```

## その他
